### PR TITLE
Initial DG-Notes Android app (Clean Architecture + MVVM + Supabase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.gradle/
+local.properties
+.idea/
+*.iml
+build/
+**/build/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# DG Notes
+
+Production-style mini Android Notes app using **Clean Architecture + MVVM + Supabase**.
+
+## Features
+- Add, list, update, and delete notes.
+- Layered architecture (`domain`, `data`, `app`).
+- Jetpack Compose UI.
+- Supabase integration (PostgREST/Auth/Realtime plugin-ready).
+
+## Setup
+1. Create a Supabase table:
+   ```sql
+   create extension if not exists "uuid-ossp";
+
+   create table if not exists notes (
+     id uuid default uuid_generate_v4() primary key,
+     content text not null,
+     created_at timestamp with time zone default now(),
+     user_id uuid
+   );
+   ```
+2. Put keys in `gradle.properties`:
+   ```properties
+   SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+   SUPABASE_ANON_KEY=YOUR_ANON_KEY
+   ```
+3. Build:
+   ```bash
+   gradle :app:assembleDebug
+   ```
+
+## Structure
+- `app/src/main/java/com/dgnotes/app/*` → UI, navigation, DI, viewmodels
+- `app/src/main/java/com/dgnotes/domain/*` → models, repositories, use cases
+- `app/src/main/java/com/dgnotes/data/*` → Supabase client and repository implementation

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,58 @@
+apply(plugin = "com.android.application")
+apply(plugin = "org.jetbrains.kotlin.android")
+apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
+
+android {
+    namespace = "com.dgnotes"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.dgnotes"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "SUPABASE_URL", "\"${project.findProperty("SUPABASE_URL") ?: ""}\"")
+        buildConfigField("String", "SUPABASE_ANON_KEY", "\"${project.findProperty("SUPABASE_ANON_KEY") ?: ""}\"")
+    }
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.14"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.2")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+
+    implementation("io.github.jan-tennert.supabase:postgrest-kt:3.2.4")
+    implementation("io.github.jan-tennert.supabase:auth-kt:3.2.4")
+    implementation("io.github.jan-tennert.supabase:realtime-kt:3.2.4")
+    implementation("io.ktor:ktor-client-android:3.1.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@android:drawable/ic_menu_edit"
+        android:label="DG Notes"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/dgnotes/MainActivity.kt
+++ b/app/src/main/java/com/dgnotes/MainActivity.kt
@@ -1,0 +1,21 @@
+package com.dgnotes
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.dgnotes.app.navigation.AppNavGraph
+import com.dgnotes.app.viewmodel.NotesViewModel
+import com.dgnotes.app.viewmodel.NotesViewModelFactory
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            val notesViewModel: NotesViewModel = viewModel(factory = NotesViewModelFactory)
+            AppNavGraph(viewModel = notesViewModel)
+        }
+    }
+}

--- a/app/src/main/java/com/dgnotes/app/di/AppModule.kt
+++ b/app/src/main/java/com/dgnotes/app/di/AppModule.kt
@@ -1,0 +1,17 @@
+package com.dgnotes.app.di
+
+import com.dgnotes.data.repository.NotesRepositoryImpl
+import com.dgnotes.domain.repository.NotesRepository
+import com.dgnotes.domain.usecase.AddNoteUseCase
+import com.dgnotes.domain.usecase.DeleteNoteUseCase
+import com.dgnotes.domain.usecase.GetNotesUseCase
+import com.dgnotes.domain.usecase.UpdateNoteUseCase
+
+object AppModule {
+    private val notesRepository: NotesRepository by lazy { NotesRepositoryImpl() }
+
+    val getNotesUseCase by lazy { GetNotesUseCase(notesRepository) }
+    val addNoteUseCase by lazy { AddNoteUseCase(notesRepository) }
+    val deleteNoteUseCase by lazy { DeleteNoteUseCase(notesRepository) }
+    val updateNoteUseCase by lazy { UpdateNoteUseCase(notesRepository) }
+}

--- a/app/src/main/java/com/dgnotes/app/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/dgnotes/app/navigation/AppNavGraph.kt
@@ -1,0 +1,19 @@
+package com.dgnotes.app.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.dgnotes.app.ui.NotesScreen
+import com.dgnotes.app.viewmodel.NotesViewModel
+
+@Composable
+fun AppNavGraph(viewModel: NotesViewModel) {
+    val navController = rememberNavController()
+
+    NavHost(navController = navController, startDestination = "notes") {
+        composable("notes") {
+            NotesScreen(viewModel)
+        }
+    }
+}

--- a/app/src/main/java/com/dgnotes/app/ui/NoteItem.kt
+++ b/app/src/main/java/com/dgnotes/app/ui/NoteItem.kt
@@ -1,0 +1,38 @@
+package com.dgnotes.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.dgnotes.domain.model.Note
+
+@Composable
+fun NoteItem(
+    note: Note,
+    onDelete: (String) -> Unit,
+    onEdit: (String, String) -> Unit
+) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 6.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(note.content, style = MaterialTheme.typography.bodyLarge)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = { onDelete(note.id) }) {
+                    Text("Delete")
+                }
+                Button(onClick = { onEdit(note.id, "${note.content} ✨") }) {
+                    Text("Quick Edit")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dgnotes/app/ui/NotesScreen.kt
+++ b/app/src/main/java/com/dgnotes/app/ui/NotesScreen.kt
@@ -1,0 +1,63 @@
+package com.dgnotes.app.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.dgnotes.app.viewmodel.NotesViewModel
+
+@Composable
+fun NotesScreen(viewModel: NotesViewModel) {
+    val notes by viewModel.notes.collectAsState()
+    var text by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text("DG Notes ✨", style = MaterialTheme.typography.headlineMedium)
+
+        Row(modifier = Modifier.padding(top = 12.dp, bottom = 16.dp)) {
+            TextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier.weight(1f),
+                placeholder = { Text("Write a note...") }
+            )
+            Button(
+                onClick = {
+                    viewModel.addNote(text)
+                    text = ""
+                },
+                modifier = Modifier.padding(start = 8.dp)
+            ) {
+                Text("Add")
+            }
+        }
+
+        LazyColumn {
+            items(notes, key = { it.id }) { note ->
+                NoteItem(
+                    note = note,
+                    onDelete = viewModel::deleteNote,
+                    onEdit = viewModel::updateNote
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/dgnotes/app/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/dgnotes/app/viewmodel/NotesViewModel.kt
@@ -1,0 +1,57 @@
+package com.dgnotes.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.dgnotes.domain.model.Note
+import com.dgnotes.domain.usecase.AddNoteUseCase
+import com.dgnotes.domain.usecase.DeleteNoteUseCase
+import com.dgnotes.domain.usecase.GetNotesUseCase
+import com.dgnotes.domain.usecase.UpdateNoteUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class NotesViewModel(
+    private val getNotes: GetNotesUseCase,
+    private val addNoteUseCase: AddNoteUseCase,
+    private val deleteNoteUseCase: DeleteNoteUseCase,
+    private val updateNoteUseCase: UpdateNoteUseCase
+) : ViewModel() {
+
+    private val _notes = MutableStateFlow<List<Note>>(emptyList())
+    val notes: StateFlow<List<Note>> = _notes.asStateFlow()
+
+    init {
+        loadNotes()
+    }
+
+    fun loadNotes() {
+        viewModelScope.launch {
+            _notes.value = runCatching { getNotes() }.getOrDefault(emptyList())
+        }
+    }
+
+    fun addNote(text: String) {
+        if (text.isBlank()) return
+        viewModelScope.launch {
+            addNoteUseCase(text.trim())
+            loadNotes()
+        }
+    }
+
+    fun deleteNote(id: String) {
+        viewModelScope.launch {
+            deleteNoteUseCase(id)
+            loadNotes()
+        }
+    }
+
+    fun updateNote(id: String, text: String) {
+        if (text.isBlank()) return
+        viewModelScope.launch {
+            updateNoteUseCase(id, text.trim())
+            loadNotes()
+        }
+    }
+}

--- a/app/src/main/java/com/dgnotes/app/viewmodel/NotesViewModelFactory.kt
+++ b/app/src/main/java/com/dgnotes/app/viewmodel/NotesViewModelFactory.kt
@@ -1,0 +1,17 @@
+package com.dgnotes.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.dgnotes.app.di.AppModule
+
+object NotesViewModelFactory : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return NotesViewModel(
+            getNotes = AppModule.getNotesUseCase,
+            addNoteUseCase = AppModule.addNoteUseCase,
+            deleteNoteUseCase = AppModule.deleteNoteUseCase,
+            updateNoteUseCase = AppModule.updateNoteUseCase
+        ) as T
+    }
+}

--- a/app/src/main/java/com/dgnotes/data/remote/SupabaseClient.kt
+++ b/app/src/main/java/com/dgnotes/data/remote/SupabaseClient.kt
@@ -1,0 +1,21 @@
+package com.dgnotes.data.remote
+
+import com.dgnotes.BuildConfig
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.realtime.Realtime
+
+object SupabaseProvider {
+    val client: SupabaseClient by lazy {
+        createSupabaseClient(
+            supabaseUrl = BuildConfig.SUPABASE_URL,
+            supabaseKey = BuildConfig.SUPABASE_ANON_KEY
+        ) {
+            install(Postgrest)
+            install(Auth)
+            install(Realtime)
+        }
+    }
+}

--- a/app/src/main/java/com/dgnotes/data/repository/NotesRepositoryImpl.kt
+++ b/app/src/main/java/com/dgnotes/data/repository/NotesRepositoryImpl.kt
@@ -1,0 +1,51 @@
+package com.dgnotes.data.repository
+
+import com.dgnotes.data.remote.SupabaseProvider
+import com.dgnotes.domain.model.Note
+import com.dgnotes.domain.repository.NotesRepository
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Columns
+import io.github.jan.supabase.postgrest.query.filter
+import io.github.jan.supabase.postgrest.query.Order as PgOrder
+import io.github.jan.supabase.postgrest.decodeList
+import io.github.jan.supabase.auth.auth
+
+class NotesRepositoryImpl : NotesRepository {
+    private val supabase = SupabaseProvider.client
+
+    override suspend fun getNotes(): List<Note> {
+        val userId = supabase.auth.currentUserOrNull()?.id
+
+        return supabase.from("notes")
+            .select(columns = Columns.list("id", "content", "created_at", "user_id")) {
+                filter { eq("user_id", userId) }
+                order("created_at", PgOrder.DESCENDING)
+            }
+            .decodeList<Note>()
+    }
+
+    override suspend fun addNote(content: String) {
+        val userId = supabase.auth.currentUserOrNull()?.id
+
+        supabase.from("notes").insert(
+            mapOf(
+                "content" to content,
+                "user_id" to userId
+            )
+        )
+    }
+
+    override suspend fun deleteNote(id: String) {
+        supabase.from("notes").delete {
+            filter { eq("id", id) }
+        }
+    }
+
+    override suspend fun updateNote(id: String, content: String) {
+        supabase.from("notes").update(
+            mapOf("content" to content)
+        ) {
+            filter { eq("id", id) }
+        }
+    }
+}

--- a/app/src/main/java/com/dgnotes/domain/model/Note.kt
+++ b/app/src/main/java/com/dgnotes/domain/model/Note.kt
@@ -1,0 +1,11 @@
+package com.dgnotes.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Note(
+    val id: String,
+    val content: String,
+    val created_at: String,
+    val user_id: String? = null
+)

--- a/app/src/main/java/com/dgnotes/domain/repository/NotesRepository.kt
+++ b/app/src/main/java/com/dgnotes/domain/repository/NotesRepository.kt
@@ -1,0 +1,10 @@
+package com.dgnotes.domain.repository
+
+import com.dgnotes.domain.model.Note
+
+interface NotesRepository {
+    suspend fun getNotes(): List<Note>
+    suspend fun addNote(content: String)
+    suspend fun deleteNote(id: String)
+    suspend fun updateNote(id: String, content: String)
+}

--- a/app/src/main/java/com/dgnotes/domain/usecase/NoteUseCases.kt
+++ b/app/src/main/java/com/dgnotes/domain/usecase/NoteUseCases.kt
@@ -1,0 +1,19 @@
+package com.dgnotes.domain.usecase
+
+import com.dgnotes.domain.repository.NotesRepository
+
+class GetNotesUseCase(private val repo: NotesRepository) {
+    suspend operator fun invoke() = repo.getNotes()
+}
+
+class AddNoteUseCase(private val repo: NotesRepository) {
+    suspend operator fun invoke(text: String) = repo.addNote(text)
+}
+
+class DeleteNoteUseCase(private val repo: NotesRepository) {
+    suspend operator fun invoke(id: String) = repo.deleteNote(id)
+}
+
+class UpdateNoteUseCase(private val repo: NotesRepository) {
+    suspend operator fun invoke(id: String, content: String) = repo.updateNote(id, content)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">DG Notes</string>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,11 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.5.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+        classpath("org.jetbrains.kotlin:kotlin-serialization:1.9.24")
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true
+SUPABASE_URL=
+SUPABASE_ANON_KEY=

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "DG-Notes"
+include(":app")


### PR DESCRIPTION
### Motivation
- Add a production-style mini Android Notes app with a layered architecture to demonstrate `domain`/`data`/`app` separation and Supabase backend integration. 
- Provide a Jetpack Compose UI and simple MVVM wiring so users can add, list, update, and delete notes. 
- Make Supabase configuration available via Gradle `BuildConfig` fields to keep keys out of source.

### Description
- Added project and module Gradle configuration (`build.gradle.kts`, `app/build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`) and `.gitignore` to bootstrap the Android app and expose `SUPABASE_URL`/`SUPABASE_ANON_KEY` as `BuildConfig` fields. 
- Implemented Supabase client provider in `SupabaseProvider` using `createSupabaseClient` and installed `Postgrest`, `Auth`, and `Realtime`. 
- Implemented `NotesRepositoryImpl` to interact with a `notes` table via Supabase PostgREST (`getNotes`, `addNote`, `deleteNote`, `updateNote`). 
- Introduced domain layer with `Note` model and use case classes (`GetNotesUseCase`, `AddNoteUseCase`, `DeleteNoteUseCase`, `UpdateNoteUseCase`). 
- Added MVVM plumbing: `NotesViewModel`, `NotesViewModelFactory`, and a simple DI object `AppModule` exposing use cases. 
- Added Compose UI and navigation: `MainActivity`, `AppNavGraph`, `NotesScreen`, and `NoteItem`, plus `AndroidManifest.xml` and resources; included a `README.md` with setup instructions. 

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1821971e4832399d4af26659d4520)